### PR TITLE
nagare: use upstream renderer, surface errors, and add chart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/saasuke-labs/gengo/main/install/ins
 - 🖥️ Terminal UI with [Bubble Tea](https://github.com/charmbracelet/bubbletea) & [Charm](https://charm.sh/)
 - 📊 Real-time progress bars and status messages
 - 💻 `--plain` mode for CI-friendly output (e.g., GitHub Actions)
+- 🧭 Nagare Markdown rendering for both diagrams and charts, with inline error output when a Nagare block fails to render cleanly
 - 🔐 Non-commercial license with optional commercial licensing
 
 ---

--- a/pkg/nagare/README.md
+++ b/pkg/nagare/README.md
@@ -2,59 +2,57 @@
 
 This extension adds support for `nagare` code blocks in Markdown files. When a fenced code block with the language `nagare` is encountered, the extension will:
 
-1. Extract the nagare code from the code block
-2. Use the nagare library directly to render it as an SVG diagram
-3. Embed the resulting SVG into the HTML output
+1. Extract the Nagare source from the code block
+2. Call Nagare's public `pkg/nagare.RenderToSVG` entry point so both diagrams and charts are rendered through the upstream renderer
+3. Show an inline error message plus the original source block when Nagare returns an error or only produces an empty/background-only SVG
+4. Embed successful SVG output directly into the HTML
 
 ## Usage
 
 In your markdown files, use fenced code blocks with `nagare` as the language:
 
 ````markdown
-# My Document
-
-Here's some nagare code:
+# Diagram Example
 
 ```nagare
-circle(50, 50, 30)
-fill("red")
-text("Hello World", 10, 100)
+@layout(w:500,h:300)
+client:Browser(url: "https://example.com", text: "Web App", x:50,y:100,w:180,h:120)
+server:Server(title: "API Server", icon: "server", port: 8080, x:300,y:100,w:150,h:50)
+client.e --> server.w
 ```
 
-Regular markdown continues here...
+# Chart Example
+
+```nagare
+chart
+title: Test Chart
+xaxis: number
+
+series: test
+color: #ff0000
+data:
+  0: 10
+  1: 20
+  2: 15
+```
 ````
-
-## How it works
-
-The extension uses the [nagare](https://github.com/saasuke-labs/nagare) Go library to convert nagare code into SVG diagrams. This happens during the markdown processing phase, with no external service dependencies.
 
 ## Error Handling
 
-If there's an error rendering the nagare code, the extension will:
+If Nagare cannot render a block cleanly, Gengo renders:
 
-1. Display an error message with details
-2. Fall back to rendering the original nagare code as a regular code block
+1. A visible `nagare-error` message containing the upstream error text when available
+2. The original `nagare` source block so the author can inspect and fix it
 
-Example fallback output:
-
-```html
-<div class="nagare-error">
-  <p><strong>Error processing nagare block:</strong> syntax error on line 2</p>
-</div>
-<pre><code class="language-nagare">
-circle(50, 50, 30)
-fill("red")
-text("Hello World", 10, 100)
-</code></pre>
-```
+That also covers cases where Nagare returns an almost-empty SVG containing only the background rectangle.
 
 ## Implementation Details
 
 The extension works by:
 
-1. Using a Goldmark AST transformer to detect fenced code blocks with language "nagare"
+1. Using a Goldmark AST transformer to detect fenced code blocks with language `nagare`
 2. Converting them to custom `NagareCodeBlock` AST nodes
-3. Using a custom renderer that calls the nagare library directly
-4. Rendering the resulting SVG inline in the HTML
+3. Calling Nagare's public renderer entry point so chart-vs-diagram detection stays aligned with upstream behavior
+4. Rejecting empty/background-only SVG responses before embedding them inline
 
-This approach ensures compatibility with other Goldmark extensions and maintains the performance benefits of AST-based processing.
+This keeps Gengo's integration small while improving chart support and surfacing actionable rendering errors.

--- a/pkg/nagare/nagare.go
+++ b/pkg/nagare/nagare.go
@@ -2,8 +2,10 @@ package nagare
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 
-	nagarediagram "github.com/saasuke-labs/nagare/pkg/diagram"
+	nagarelib "github.com/saasuke-labs/nagare/pkg/nagare"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
@@ -41,19 +43,15 @@ func (t *NagareTransformer) Transform(node *ast.Document, reader text.Reader, pc
 		block  *NagareCodeBlock
 	}
 
-	// First pass: collect all nagare blocks
 	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
 
 		if fcb, ok := n.(*ast.FencedCodeBlock); ok {
-			// Check if this is a nagare code block
 			if fcb.Info != nil && bytes.Equal(fcb.Info.Value(reader.Source()), []byte("nagare")) {
-				// Create a new NagareCodeBlock
 				nagareBlock := &NagareCodeBlock{}
 
-				// Copy content from the fenced code block
 				var content bytes.Buffer
 				for i := 0; i < fcb.Lines().Len(); i++ {
 					line := fcb.Lines().At(i)
@@ -61,7 +59,6 @@ func (t *NagareTransformer) Transform(node *ast.Document, reader text.Reader, pc
 				}
 				nagareBlock.Content = content.Bytes()
 
-				// Store for replacement
 				nagareBlocks = append(nagareBlocks, struct {
 					parent ast.Node
 					fcb    *ast.FencedCodeBlock
@@ -73,15 +70,13 @@ func (t *NagareTransformer) Transform(node *ast.Document, reader text.Reader, pc
 		return ast.WalkContinue, nil
 	})
 
-	// Second pass: replace all collected blocks
 	for _, nb := range nagareBlocks {
 		nb.parent.ReplaceChild(nb.parent, nb.fcb, nb.block)
 	}
 }
 
 // NagareRenderer renders nagare code blocks using the nagare library
-type NagareRenderer struct {
-}
+type NagareRenderer struct{}
 
 // RegisterFuncs implements renderer.NodeRenderer.RegisterFuncs
 func (r *NagareRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
@@ -95,10 +90,8 @@ func (r *NagareRenderer) renderNagareCodeBlock(w util.BufWriter, source []byte, 
 
 	nagareBlock := node.(*NagareCodeBlock)
 
-	// Use the nagare library directly to render the diagram
-	svg, err := nagarediagram.CreateDiagram(string(nagareBlock.Content))
+	svg, err := renderNagareSVG(string(nagareBlock.Content))
 	if err != nil {
-		// Fallback: render as regular code block with error message
 		w.WriteString("<div class=\"nagare-error\">")
 		w.WriteString("<p><strong>Error processing nagare block:</strong> ")
 		w.Write(util.EscapeHTML([]byte(err.Error())))
@@ -110,15 +103,40 @@ func (r *NagareRenderer) renderNagareCodeBlock(w util.BufWriter, source []byte, 
 		return ast.WalkContinue, nil
 	}
 
-	// Write the SVG directly
 	w.WriteString(svg)
-
 	return ast.WalkContinue, nil
 }
 
-// Extension represents the nagare extension
-type Extension struct {
+func renderNagareSVG(code string) (string, error) {
+	svg, err := nagarelib.RenderToSVG(code)
+	if err != nil {
+		return "", err
+	}
+	trimmed := strings.TrimSpace(svg)
+	if trimmed == "" {
+		return "", fmt.Errorf("nagare returned an empty SVG")
+	}
+	if isBareBackgroundSVG(trimmed) {
+		return "", fmt.Errorf("nagare rendered only a background; check the block for chart or diagram errors")
+	}
+	return svg, nil
 }
+
+func isBareBackgroundSVG(svg string) bool {
+	if !strings.Contains(svg, "<svg") {
+		return false
+	}
+	graphicTags := []string{"<g", "<circle", "<line", "<polyline", "<path", "<text", "<ellipse", "<polygon"}
+	for _, tag := range graphicTags {
+		if strings.Contains(svg, tag) {
+			return false
+		}
+	}
+	return strings.Count(svg, "<rect") == 1
+}
+
+// Extension represents the nagare extension
+type Extension struct{}
 
 // Extend implements goldmark.Extender.Extend
 func (e *Extension) Extend(m goldmark.Markdown) {
@@ -131,6 +149,4 @@ func (e *Extension) Extend(m goldmark.Markdown) {
 }
 
 // NewNagareExtension creates a new nagare extension
-func NewNagareExtension() *Extension {
-	return &Extension{}
-}
+func NewNagareExtension() *Extension { return &Extension{} }

--- a/pkg/nagare/nagare_test.go
+++ b/pkg/nagare/nagare_test.go
@@ -8,72 +8,25 @@ import (
 	"github.com/yuin/goldmark"
 )
 
-func TestNagareExtension(t *testing.T) {
-	// Create markdown with nagare extension
-	md := goldmark.New(
+func newTestMarkdown() goldmark.Markdown {
+	return goldmark.New(
 		goldmark.WithExtensions(
 			NewNagareExtension(),
 		),
 	)
-
-	// Test markdown with nagare code block
-	markdown := "# Test Page\n\nHere's a nagare block:\n\n```nagare\ncircle(50, 50, 30)\n```\n\nAnd some regular text."
-
-	var buf bytes.Buffer
-	if err := md.Convert([]byte(markdown), &buf); err != nil {
-		t.Fatalf("Failed to convert markdown: %v", err)
-	}
-
-	result := buf.String()
-
-	// Check that SVG is generated
-	if !strings.Contains(result, "<svg") {
-		t.Errorf("Expected SVG output in result, got: %s", result)
-	}
-
-	// Check that heading and text are still present
-	if !strings.Contains(result, "<h1>Test Page</h1>") {
-		t.Errorf("Expected heading in result, got: %s", result)
-	}
-
-	if !strings.Contains(result, "And some regular text") {
-		t.Errorf("Expected regular text in result, got: %s", result)
-	}
-
-	t.Logf("Generated HTML length: %d", len(result))
 }
 
-func TestNagareExtensionMultipleBlocks(t *testing.T) {
-	// Create markdown with nagare extension
-	md := goldmark.New(
-		goldmark.WithExtensions(
-			NewNagareExtension(),
-		),
-	)
-
-	// Test markdown with multiple nagare code blocks
+func TestNagareExtensionRendersModernDiagramDSL(t *testing.T) {
+	md := newTestMarkdown()
 	markdown := `# Test Page
 
-First nagare block:
+Modern diagram:
 
 ` + "```nagare" + `
-circle(50, 50, 30)
-` + "```" + `
-
-Some text in between.
-
-Second nagare block:
-
-` + "```nagare" + `
-rectangle(10, 10, 100, 50)
-` + "```" + `
-
-More text.
-
-Third nagare block:
-
-` + "```nagare" + `
-line(0, 0, 200, 200)
+@layout(w:500,h:300)
+client:Browser(url: "https://example.com", text: "Web App", x:50,y:100,w:180,h:120)
+server:Server(title: "API Server", icon: "server", port: 8080, x:300,y:100,w:150,h:50)
+client.e --> server.w
 ` + "```" + `
 `
 
@@ -83,36 +36,103 @@ line(0, 0, 200, 200)
 	}
 
 	result := buf.String()
+	if !strings.Contains(result, "<svg") {
+		t.Fatalf("Expected SVG output in result, got: %s", result)
+	}
+	if !strings.Contains(result, "<polyline") {
+		t.Errorf("Expected rendered connector in modern diagram output, got: %s", result)
+	}
+	if !strings.Contains(result, "<g transform=\"translate(50.000000,100.000000)\"") {
+		t.Errorf("Expected translated component group in modern diagram output, got: %s", result)
+	}
+}
 
-	// Count how many SVG elements are in the result (one per nagare block)
+func TestNagareExtensionRendersCharts(t *testing.T) {
+	md := newTestMarkdown()
+	markdown := `# Chart Page
+
+` + "```nagare" + `
+chart
+title: Test Chart
+xaxis: number
+
+series: test
+color: #ff0000
+data:
+  0: 10
+  1: 20
+  2: 15
+` + "```" + `
+`
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(markdown), &buf); err != nil {
+		t.Fatalf("Failed to convert markdown: %v", err)
+	}
+
+	result := buf.String()
+	if !strings.Contains(result, "<svg") {
+		t.Fatalf("Expected SVG output in result, got: %s", result)
+	}
+	if !strings.Contains(result, "Test Chart") {
+		t.Errorf("Expected chart title in rendered output, got: %s", result)
+	}
+	if !strings.Contains(result, "<path") {
+		t.Errorf("Expected chart line path in rendered output, got: %s", result)
+	}
+}
+
+func TestNagareExtensionMultipleBlocks(t *testing.T) {
+	md := newTestMarkdown()
+	markdown := `# Test Page
+
+First nagare block:
+
+` + "```nagare" + `
+@layout(w:500,h:300)
+client:Browser(url: "https://example.com", text: "Web App", x:50,y:100,w:180,h:120)
+server:Server(title: "API Server", icon: "server", port: 8080, x:300,y:100,w:150,h:50)
+client.e --> server.w
+` + "```" + `
+
+Some text in between.
+
+Second nagare block:
+
+` + "```nagare" + `
+chart
+title: Secondary Chart
+xaxis: number
+
+series: load
+color: #22c55e
+data:
+  0: 1
+  1: 3
+  2: 2
+` + "```" + `
+`
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(markdown), &buf); err != nil {
+		t.Fatalf("Failed to convert markdown: %v", err)
+	}
+
+	result := buf.String()
 	svgCount := strings.Count(result, "<svg")
-	if svgCount != 3 {
-		t.Errorf("Expected 3 SVG elements, got %d", svgCount)
+	if svgCount != 2 {
+		t.Errorf("Expected 2 SVG elements, got %d", svgCount)
 	}
-
-	// Check that all sections are present
-	if !strings.Contains(result, "First nagare block:") {
-		t.Errorf("Expected 'First nagare block:' in result")
+	if !strings.Contains(result, "Secondary Chart") {
+		t.Errorf("Expected rendered chart title in result, got: %s", result)
 	}
-	if !strings.Contains(result, "Second nagare block:") {
-		t.Errorf("Expected 'Second nagare block:' in result")
+	if !strings.Contains(result, "<polyline") {
+		t.Errorf("Expected rendered diagram connector in result, got: %s", result)
 	}
-	if !strings.Contains(result, "Third nagare block:") {
-		t.Errorf("Expected 'Third nagare block:' in result")
-	}
-
-	t.Logf("Multiple blocks test passed, generated %d SVGs", svgCount)
 }
 
 func TestNagareExtensionInvalidCode(t *testing.T) {
-	// Create markdown with nagare extension
-	md := goldmark.New(
-		goldmark.WithExtensions(
-			NewNagareExtension(),
-		),
-	)
-
-	// Test markdown with invalid nagare code block
+	md := newTestMarkdown()
 	markdown := "# Test Page\n\nHere's a bad nagare block:\n\n```nagare\nthis is invalid nagare syntax\n```\n\nRegular text."
 
 	var buf bytes.Buffer
@@ -121,22 +141,13 @@ func TestNagareExtensionInvalidCode(t *testing.T) {
 	}
 
 	result := buf.String()
-
-	// The nagare extension should either:
-	// 1. Generate an error div with "Error processing nagare block:", or
-	// 2. Still generate some output (nagare might parse it differently)
-	// We check for the error message div if nagare fails to parse
-	hasErrorDiv := strings.Contains(result, "Error processing nagare block:")
-	hasHeading := strings.Contains(result, "<h1>Test Page</h1>")
-	hasRegularText := strings.Contains(result, "Regular text")
-
-	// At minimum, the heading and regular text should be present
-	if !hasHeading {
-		t.Errorf("Expected heading in result")
+	if !strings.Contains(result, "Error processing nagare block:") {
+		t.Errorf("Expected error div in result, got: %s", result)
 	}
-	if !hasRegularText {
+	if !strings.Contains(result, "this is invalid nagare syntax") {
+		t.Errorf("Expected original invalid block content in result, got: %s", result)
+	}
+	if !strings.Contains(result, "Regular text") {
 		t.Errorf("Expected regular text in result")
 	}
-
-	t.Logf("Invalid code test result: error_div=%v, has_heading=%v, has_text=%v", hasErrorDiv, hasHeading, hasRegularText)
 }


### PR DESCRIPTION
### Motivation
- Integrate Gengo's `nagare` code block support with the upstream renderer so modern diagram DSL and chart blocks are handled consistently. 
- Surface actionable rendering errors inline and avoid embedding empty/background-only SVGs that provide no useful output. 
- Improve documentation to advertise chart + diagram rendering support and show fallback behavior when rendering fails.

### Description
- Replace the previous internal diagram call with a wrapper that calls `pkg/nagare.RenderToSVG` via `renderNagareSVG` to centralize rendering behavior and error handling. 
- Add `isBareBackgroundSVG` to detect and reject empty/background-only SVG results and return a clear error instead of embedding unusable SVG. 
- Update the Goldmark AST transformer/renderer to embed successful SVG output inline and to emit an error div plus the original source block when rendering fails. 
- Expand and modernize tests in `pkg/nagare/nagare_test.go` to cover modern diagram DSL, chart rendering, multiple blocks, and invalid input, and update README files to document the feature and error behavior.

### Testing
- Ran unit tests for the package with `go test ./pkg/nagare -v`; all tests passed. 
- Ran repository tests with `go test ./...` to validate integration; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf711c9808328871e6052f44003d2)